### PR TITLE
Dockerfile: add wglozer/ prefix to image path, build script

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM xcc:base
+FROM wglozer/xcc:base
 
 ARG TARGET=x86_64-linux-musl
 ARG TOOLCHAIN=1.34.0

--- a/scripts/start-build-env.sh
+++ b/scripts/start-build-env.sh
@@ -1,0 +1,3 @@
+set -e
+docker build -t kprobe-build -f build/Dockerfile .
+docker run -it -v"$(pwd)":/work --volume $SSH_AUTH_SOCK:/ssh-agent --env SSH_AUTH_SOCK=/ssh-agent kprobe-build


### PR DESCRIPTION
Docker gets confused as xcc is not a legit dockerhub path
Build script to save me from grepping through history