### PR TITLE
Add per-cpu fanout mode

### DIFF
--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -52,7 +52,7 @@ impl FromStr for Mode {
         match mode {
             "hash" => Ok(Mode::Hash),
             "lb"   => Ok(Mode::LB),
-	    "cpu"  => Ok(Mode::CPU),
+            "cpu"  => Ok(Mode::CPU),
             _      => Err(anyhow!("invalid fanout mode"))
         }
     }

--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -4,12 +4,14 @@ use pcap::{Capture, Active};
 
 const PACKET_FANOUT_HASH: u32 = 0x0;
 const PACKET_FANOUT_LB:   u32 = 0x1;
+const PACKET_FANOUT_CPU:  u32 = 0x2;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(u32)]
 pub enum Mode {
     Hash = PACKET_FANOUT_HASH,
     LB   = PACKET_FANOUT_LB,
+    CPU  = PACKET_FANOUT_CPU,
 }
 
 #[cfg(target_os = "linux")]
@@ -50,6 +52,7 @@ impl FromStr for Mode {
         match mode {
             "hash" => Ok(Mode::Hash),
             "lb"   => Ok(Mode::LB),
+	    "cpu"  => Ok(Mode::CPU),
             _      => Err(anyhow!("invalid fanout mode"))
         }
     }


### PR DESCRIPTION
see https://github.com/kentik/kprobe/issues/33

By assigning packets on per-cpu basis we ensure kernel's skb structure (incl locks) gets shared across fewer cores than other fanout strategies. This should result in higher throughput/lower resource usage.

As per `man 8 ethtool`, all the valid `-N -U --config-nfc --config-ntuple` options make sure flows get always scheduled to the same core so by using PACKET_FANOUT_CPU we ensure that packets from the same flow get assigned to the same socket.

Let's give it a try!